### PR TITLE
Add /docs redirect

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+
+// Redirect users from /docs to the main documentation page
+
+export default function DocsRedirectPage() {
+  redirect('/documentation');
+}
+


### PR DESCRIPTION
## Summary
- add `/docs` route that redirects users to `/documentation`

## Testing
- `npm run build`
- `npm run lint` *(prompts for config)*
- `npm run typecheck` *(fails: object literal may only specify known properties)*
- `npm run dev` and `curl -I http://localhost:3000/docs -L`


------
https://chatgpt.com/codex/tasks/task_e_6872ed51a748832491e9a9f40921d773